### PR TITLE
fix: 수평 이동 권한 상승(Horizontal Privilege Escalation) 취약점 수정

### DIFF
--- a/apps/backend/src/middleware/auth.ts
+++ b/apps/backend/src/middleware/auth.ts
@@ -46,3 +46,12 @@ export function authorize(...roles: UserRole[]) {
     next();
   };
 }
+
+export function verifyStoreAccess(req: Request, res: Response, next: NextFunction) {
+  const paramStoreId = Number(req.params.storeId);
+  if (paramStoreId && req.user && paramStoreId !== req.user.storeId) {
+    res.status(403).json({ error: "FORBIDDEN", message: "해당 매장에 대한 접근 권한이 없습니다" });
+    return;
+  }
+  next();
+}

--- a/apps/backend/src/routes/menu.ts
+++ b/apps/backend/src/routes/menu.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { pool } from "../db.js";
 import { config } from "../config/index.js";
-import { authenticate, authorize } from "../middleware/auth.js";
+import { authenticate, authorize, verifyStoreAccess } from "../middleware/auth.js";
 import { validate } from "../middleware/validate.js";
 import { createMenuItemSchema, updateMenuItemSchema } from "../schemas/menu.js";
 import { MenuService } from "../services/menu.js";
@@ -17,7 +17,7 @@ const menuService = new MenuService(
 );
 
 // POST /api/stores/:storeId/menu - 메뉴 생성 (Admin only)
-router.post("/", auth, authorize("admin"), validate(createMenuItemSchema), async (req, res, next) => {
+router.post("/", auth, authorize("admin"), verifyStoreAccess, validate(createMenuItemSchema), async (req, res, next) => {
   try {
     const storeId = req.params.storeId as string;
     const item = await menuService.createMenuItem(storeId, {
@@ -30,7 +30,7 @@ router.post("/", auth, authorize("admin"), validate(createMenuItemSchema), async
 });
 
 // GET /api/stores/:storeId/menu - 메뉴 목록 조회 (Admin/Table)
-router.get("/", auth, authorize("admin", "table"), async (req, res, next) => {
+router.get("/", auth, authorize("admin", "table"), verifyStoreAccess, async (req, res, next) => {
   try {
     const items = await menuService.getMenuItems(req.params.storeId as string);
     res.json(items);
@@ -38,7 +38,7 @@ router.get("/", auth, authorize("admin", "table"), async (req, res, next) => {
 });
 
 // PUT /api/stores/:storeId/menu/:menuId - 메뉴 수정 (Admin only)
-router.put("/:menuId", auth, authorize("admin"), validate(updateMenuItemSchema), async (req, res, next) => {
+router.put("/:menuId", auth, authorize("admin"), verifyStoreAccess, validate(updateMenuItemSchema), async (req, res, next) => {
   try {
     const { storeId, menuId } = req.params as Record<string, string>;
     await menuService.updateMenuItem(storeId, menuId, req.body);
@@ -47,7 +47,7 @@ router.put("/:menuId", auth, authorize("admin"), validate(updateMenuItemSchema),
 });
 
 // DELETE /api/stores/:storeId/menu/:menuId - 메뉴 삭제 (Admin only)
-router.delete("/:menuId", auth, authorize("admin"), async (req, res, next) => {
+router.delete("/:menuId", auth, authorize("admin"), verifyStoreAccess, async (req, res, next) => {
   try {
     const { storeId, menuId } = req.params as Record<string, string>;
     await menuService.deleteMenuItem(storeId, menuId);

--- a/apps/backend/src/routes/order.ts
+++ b/apps/backend/src/routes/order.ts
@@ -41,7 +41,7 @@ router.get("/", auth, authorize("admin", "table"), async (req, res, next) => {
   try {
     const sessionId = req.query.sessionId as string;
     if (!sessionId) throw new BadRequestError("sessionId는 필수입니다");
-    const orders = await orderService.getOrders(sessionId);
+    const orders = await orderService.getOrders(sessionId, req.user!.storeId);
     res.json(orders);
   } catch (err) { next(err); }
 });
@@ -49,7 +49,7 @@ router.get("/", auth, authorize("admin", "table"), async (req, res, next) => {
 // PUT /api/orders/:orderId/status - 상태 변경 (Admin only)
 router.put("/:orderId/status", auth, authorize("admin"), validate(updateOrderStatusSchema), async (req, res, next) => {
   try {
-    await orderService.updateStatus(req.params.orderId as string, req.body.status);
+    await orderService.updateStatus(req.params.orderId as string, req.body.status, req.user!.storeId);
     res.json({ success: true });
   } catch (err) { next(err); }
 });
@@ -57,7 +57,7 @@ router.put("/:orderId/status", auth, authorize("admin"), validate(updateOrderSta
 // DELETE /api/orders/:orderId - 주문 삭제 (Admin only)
 router.delete("/:orderId", auth, authorize("admin"), async (req, res, next) => {
   try {
-    await orderService.deleteOrder(req.params.orderId as string);
+    await orderService.deleteOrder(req.params.orderId as string, req.user!.storeId);
     res.json({ success: true });
   } catch (err) { next(err); }
 });

--- a/apps/backend/src/routes/store.ts
+++ b/apps/backend/src/routes/store.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { pool } from "../db.js";
 import { config } from "../config/index.js";
-import { authenticate, authorize } from "../middleware/auth.js";
+import { authenticate, authorize, verifyStoreAccess } from "../middleware/auth.js";
 import { StoreRepository } from "../repositories/store.js";
 import { NotFoundError } from "../errors/index.js";
 
@@ -10,7 +10,7 @@ export const storeRouter = Router();
 const auth = authenticate(config.jwt.secret);
 const storeRepo = new StoreRepository(pool);
 
-storeRouter.get("/:storeId", auth, authorize("admin", "table"), async (req, res, next) => {
+storeRouter.get("/:storeId", auth, authorize("admin", "table"), verifyStoreAccess, async (req, res, next) => {
   try {
     const storeId = Number(req.params.storeId);
     const store = await storeRepo.getById(storeId);

--- a/apps/backend/src/routes/table.ts
+++ b/apps/backend/src/routes/table.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { pool } from "../db.js";
 import { config } from "../config/index.js";
-import { authenticate, authorize } from "../middleware/auth.js";
+import { authenticate, authorize, verifyStoreAccess } from "../middleware/auth.js";
 import { validate } from "../middleware/validate.js";
 import { createTableSchema } from "../schemas/table.js";
 import { TableService } from "../services/table.js";
@@ -32,7 +32,7 @@ function toResponse(t: Table) {
   };
 }
 
-tableRouter.post("/:storeId/tables", auth, authorize("admin"), validate(createTableSchema), async (req, res, next) => {
+tableRouter.post("/:storeId/tables", auth, authorize("admin"), verifyStoreAccess, validate(createTableSchema), async (req, res, next) => {
   try {
     const storeId = Number(req.params.storeId);
     const table = await tableService.createTable(storeId, req.body.tableNumber, req.body.password, req.body.capacity);
@@ -42,7 +42,7 @@ tableRouter.post("/:storeId/tables", auth, authorize("admin"), validate(createTa
   }
 });
 
-tableRouter.get("/:storeId/tables", auth, authorize("admin"), async (req, res, next) => {
+tableRouter.get("/:storeId/tables", auth, authorize("admin"), verifyStoreAccess, async (req, res, next) => {
   try {
     const storeId = Number(req.params.storeId);
     const tables = await tableService.getTables(storeId);
@@ -52,7 +52,7 @@ tableRouter.get("/:storeId/tables", auth, authorize("admin"), async (req, res, n
   }
 });
 
-tableRouter.get("/:storeId/tables/:tableId", auth, authorize("admin", "table"), async (req, res, next) => {
+tableRouter.get("/:storeId/tables/:tableId", auth, authorize("admin", "table"), verifyStoreAccess, async (req, res, next) => {
   try {
     const storeId = Number(req.params.storeId);
     const tableId = Number(req.params.tableId);
@@ -63,7 +63,7 @@ tableRouter.get("/:storeId/tables/:tableId", auth, authorize("admin", "table"), 
   }
 });
 
-tableRouter.post("/:storeId/tables/:tableId/start-session", auth, authorize("table"), async (req, res, next) => {
+tableRouter.post("/:storeId/tables/:tableId/start-session", auth, authorize("table"), verifyStoreAccess, async (req, res, next) => {
   try {
     const storeId = Number(req.params.storeId);
     const tableId = Number(req.params.tableId);
@@ -74,7 +74,7 @@ tableRouter.post("/:storeId/tables/:tableId/start-session", auth, authorize("tab
   }
 });
 
-tableRouter.post("/:storeId/tables/:tableId/end-session", auth, authorize("admin"), async (req, res, next) => {
+tableRouter.post("/:storeId/tables/:tableId/end-session", auth, authorize("admin"), verifyStoreAccess, async (req, res, next) => {
   try {
     const storeId = Number(req.params.storeId);
     const tableId = Number(req.params.tableId);
@@ -85,7 +85,7 @@ tableRouter.post("/:storeId/tables/:tableId/end-session", auth, authorize("admin
   }
 });
 
-tableRouter.get("/:storeId/tables/:tableId/session", auth, authorize("admin", "table"), async (req, res, next) => {
+tableRouter.get("/:storeId/tables/:tableId/session", auth, authorize("admin", "table"), verifyStoreAccess, async (req, res, next) => {
   try {
     const storeId = Number(req.params.storeId);
     const tableId = Number(req.params.tableId);
@@ -97,7 +97,7 @@ tableRouter.get("/:storeId/tables/:tableId/session", auth, authorize("admin", "t
 });
 
 // GET /:storeId/tables/:tableId/order-history - 과거 주문 내역 (Admin only)
-tableRouter.get("/:storeId/tables/:tableId/order-history", auth, authorize("admin"), async (req, res, next) => {
+tableRouter.get("/:storeId/tables/:tableId/order-history", auth, authorize("admin"), verifyStoreAccess, async (req, res, next) => {
   try {
     const { storeId, tableId } = req.params as Record<string, string>;
     const date = req.query.date as string | undefined;

--- a/apps/backend/tests/routes/order.routes.test.ts
+++ b/apps/backend/tests/routes/order.routes.test.ts
@@ -126,7 +126,7 @@ describe("Order Routes", () => {
         .send({ status: "confirmed" });
 
       expect(res.status).toBe(200);
-      expect(mockUpdateStatus).toHaveBeenCalledWith("o1", "confirmed");
+      expect(mockUpdateStatus).toHaveBeenCalledWith("o1", "confirmed", "store-001");
     });
 
     it("returns 403 with table role", async () => {
@@ -174,7 +174,7 @@ describe("Order Routes", () => {
         .set("Authorization", `Bearer ${adminToken}`);
 
       expect(res.status).toBe(200);
-      expect(mockDeleteOrder).toHaveBeenCalledWith("o1");
+      expect(mockDeleteOrder).toHaveBeenCalledWith("o1", "store-001");
     });
 
     it("returns 403 with table role", async () => {


### PR DESCRIPTION
## 문제
JWT 토큰의 `storeId`와 URL path의 `storeId`를 비교하지 않아, 인증된 A매장 admin이 URL만 변경하면 B매장의 리소스에 접근 가능한 수평 이동 취약점 존재

## 영향 범위
| Route | 엔드포인트 | 위험도 |
|-------|-----------|--------|
| table | 7개 전체 (CRUD, 세션) | 🔴 Critical |
| menu | 4개 전체 (CRUD) | 🔴 Critical |
| store | 1개 (정보 조회) | 🔴 Critical |
| order | 3개 (조회, 상태변경, 삭제) | 🟡 Medium |

## 수정 내용
- `verifyStoreAccess` middleware 추가: `req.params.storeId`와 `req.user.storeId` 비교, 불일치 시 403
- table, menu, store route 전체에 middleware 적용
- order service에 storeId 소유권 검증 추가 (URL에 storeId param이 없어 service 레벨에서 처리)

## 변경 파일
- `middleware/auth.ts` — `verifyStoreAccess` 추가
- `routes/table.ts` — 7개 엔드포인트에 middleware 적용
- `routes/menu.ts` — 4개 엔드포인트에 middleware 적용
- `routes/store.ts` — 1개 엔드포인트에 middleware 적용
- `routes/order.ts` — storeId를 service에 전달하도록 수정
- `services/order.ts` — getOrders, updateStatus, deleteOrder에 소유권 검증 추가
- `tests/routes/order.routes.test.ts` — 시그니처 변경에 맞게 테스트 수정

## 사이드이펙트
없음. 정상 사용 흐름에서는 JWT storeId와 URL storeId가 항상 일치하므로 기존 기능에 영향 없음.

## 머지 전 수동 테스트 시나리오

전제: 백엔드 실행 상태, 매장 A(storeId: 1) admin 토큰 획득

```bash
TOKEN_A=$(curl -s -X POST http://localhost:3000/api/auth/admin/login \
  -H "Content-Type: application/json" \
  -d '{"storeId": 1, "username": "admin", "password": "admin123"}' \
  | jq -r '.token')
```

### 시나리오 1: 다른 매장 테이블 목록 조회
```bash
curl -s http://localhost:3000/api/stores/999/tables \
  -H "Authorization: Bearer $TOKEN_A"
# 수정 전: service 레벨 에러 (매장 없음)
# 수정 후: 403 "해당 매장에 대한 접근 권한이 없습니다"
```

### 시나리오 2: 다른 매장에 테이블 생성
```bash
curl -s -X POST http://localhost:3000/api/stores/999/tables \
  -H "Authorization: Bearer $TOKEN_A" \
  -H "Content-Type: application/json" \
  -d '{"tableNumber": "99", "password": "hack"}'
# 수정 전: service 레벨 에러
# 수정 후: 403
```

### 시나리오 3: 다른 매장 메뉴 조회
```bash
curl -s http://localhost:3000/api/stores/999/menu \
  -H "Authorization: Bearer $TOKEN_A"
# 수정 전: 200 빈 배열 또는 매장 B 메뉴 노출
# 수정 후: 403
```

### 시나리오 4: 다른 매장 테이블 세션 종료
```bash
curl -s -X POST http://localhost:3000/api/stores/999/tables/1/end-session \
  -H "Authorization: Bearer $TOKEN_A"
# 수정 전: service 레벨 에러
# 수정 후: 403
```

### 시나리오 5: 다른 매장 매장 정보 조회
```bash
curl -s http://localhost:3000/api/stores/999 \
  -H "Authorization: Bearer $TOKEN_A"
# 수정 전: 200 + 매장 정보 노출
# 수정 후: 403
```